### PR TITLE
[minor] source dir path fix

### DIFF
--- a/media-sound/deadbeef/deadbeef-0.7.1.ebuild
+++ b/media-sound/deadbeef/deadbeef-0.7.1.ebuild
@@ -133,7 +133,7 @@ DEPEND="${RDEPEND}
 	mac? ( x86? ( dev-lang/yasm:0 )
 		amd64? ( dev-lang/yasm:0 ) )"
 
-S="${WORKDIR}/${PN}-${PVR}"
+S="${WORKDIR}/${P}"
 
 src_prepare() {
 	if ! use_if_iuse linguas_pt_BR && use_if_iuse linguas_ru ; then

--- a/media-sound/deadbeef/deadbeef-0.7.1.ebuild
+++ b/media-sound/deadbeef/deadbeef-0.7.1.ebuild
@@ -133,7 +133,7 @@ DEPEND="${RDEPEND}
 	mac? ( x86? ( dev-lang/yasm:0 )
 		amd64? ( dev-lang/yasm:0 ) )"
 
-S="${WORKDIR}/${PN}-${MY_PV}"
+S="${WORKDIR}/${PN}-${PVR}"
 
 src_prepare() {
 	if ! use_if_iuse linguas_pt_BR && use_if_iuse linguas_ru ; then


### PR DESCRIPTION
ebuilf fix for build error:

 * ERROR: media-sound/deadbeef-0.7.1::deadbeef-overlay failed (prepare phase):
 *   The source directory '/var/tmp/portage/media-sound/deadbeef-0.7.1/work/deadbeef-' doesn't exist